### PR TITLE
Correct invalid function to match other examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ import Todo from './Todo';
 
 // simple subscription to the collection "todos"
 const mapDataToProps = {
-  todos(hz) => hz('todos')
+  todos: (hz) => hz('todos')
 };
 
 const TodoList = (props) => (


### PR DESCRIPTION
Just a small one. I spotted this was different to the other examples.
